### PR TITLE
Removed colons on headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ProtectionPerms:
+# ProtectionPerms
 ProtectionPerms is a simple player protection and control plugin inspired by plugins like ModifyWorld or NoItem.  It's aim is to provide an easy, permissions-based way of preventing players from performing certain actions on your server, such as breaking blocks, damaging entities, or using items.
 
-## Permssions:
+## Permssions
 At this time, ProtectionPerms is completely based off permissions.  Without a given permission, players will **not** be able to perform the action the permission specifies.  Currently, permissions come in three flavors:
 
-### Block Permissions:
+### Block Permissions
 
 * `protectionperms.block.interact.<blockID>.primary` - Player can primary interact (left-click) on `blockID`. 
   * Example: `protectionperms.block.interact.minecraft:stone.primary`
@@ -18,7 +18,7 @@ At this time, ProtectionPerms is completely based off permissions.  Without a gi
 * `protectionperms.block.place.<blockID>` - Player can place `blockID`. 
   * Example: `protectionperms.block.place.minecraft:stone`
 
-### Entity Permissions:
+### Entity Permissions
 
 * `protectionperms.entity.interact.<entityID>.primary` - Player can primary interact (left-click) on `enityName`.
   * Example: `protectionperms.entity.interact.minecraft:zombie.primary`
@@ -41,7 +41,7 @@ At this time, ProtectionPerms is completely based off permissions.  Without a gi
 * `protectionperms.entity.hook.<entityID>` - Player can hook `enityName` with a fishing pole. 
   * Example: `protectionperms.entity.hook.minecraft:sheep`
 
-### Item Permissions:
+### Item Permissions
 
 * `protectionperms.item.use.<itemID>.on.self` - Player can use (right-click) with `itemID` on themselves (Example: eating bread). 
   * Example: `protectionperms.item.use.minecraft:bread.on.self`
@@ -70,7 +70,7 @@ At this time, ProtectionPerms is completely based off permissions.  Without a gi
 * `protectionperms.item.fuel.<itemID>` - Player can us `itemID` as fuel in a furance. 
   * Example: `protectionperms.item.fuel.minecraft:coal`
 
-#### A Note on BlockStates:
+#### A Note on BlockStates
 Whenever a permission requires a blockID you can optionally include `BlockState` information. For example if I wanted to give the player permission to break Andesite but not regular stone I could give them the permission `protectionperms.block.break.minecraft:stone[variant=andesite]`. Giving the player the `protectionperms.block.break.minecraft:stone` permission still allows them to break all variants of stone as normal.
 
 When creating your permission nodes you may run into situations where you have conflicting permissions. For instance, you may not be able to place a block even though you have the place permission because you don't have the corresponding use permission for the block as an item, in this case pay attention to the message ProtectionPerms gives you when you try to execute an action, it should point you toward the permission node you need. :wink:


### PR DESCRIPTION
The colons at the end of every header look odd.
Feel free to reject this.